### PR TITLE
Capitalize the H in GitHub

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -2,7 +2,7 @@ import "highlight.js/styles/github-gist.css";
 import "../styles/old-layout.css";
 import Head from "next/head";
 
-# React Patterns [on Github](https://github.com/chantastic/reactpatterns.com)
+# React Patterns [on GitHub](https://github.com/chantastic/reactpatterns.com)
 
 ## Contents
 


### PR DESCRIPTION
Not sure if it matters to you, but GitHub is "properly" spelled with a capital H. Feel free to close this PR if you disagree or don't care 😄